### PR TITLE
Let Previous handle a year change

### DIFF
--- a/goweek.go
+++ b/goweek.go
@@ -42,10 +42,9 @@ func NewWeek(params ...int) (*Week, error) {
 	}
 
 	// getting first day of the given week
-	var weekNumber = week.Number
-	for weekNumber > 1 {
-		fd = fd.Add(7 * 24 * time.Hour)
-		weekNumber--
+	fd = fd.AddDate(0, 0, (week.Number-1)*7)
+	for fd.Year() > y {
+		fd = fd.AddDate(0, 0, -7)
 	}
 
 	// getting dates for whole week
@@ -76,7 +75,7 @@ func (week *Week) Previous() (*Week, error) {
 	var newYear, newWeek int
 	if week.Number-1 < 1 {
 		newYear = week.Year - 1
-		newWeek = 52
+		newWeek = 53
 	} else {
 		newYear = week.Year
 		newWeek = week.Number - 1

--- a/goweek.go
+++ b/goweek.go
@@ -76,7 +76,7 @@ func (week *Week) Previous() (*Week, error) {
 	var newYear, newWeek int
 	if week.Number-1 < 1 {
 		newYear = week.Year - 1
-		newWeek = 53
+		newWeek = 52
 	} else {
 		newYear = week.Year
 		newWeek = week.Number - 1

--- a/goweek_test.go
+++ b/goweek_test.go
@@ -57,6 +57,16 @@ var expectedDaysForPreviousWeekWithYearSwitch = []time.Time{
 	time.Date(2015, 1, 4, 0, 0, 0, 0, time.UTC),
 }
 
+var expectedDaysForPreviousWeekWithYearSwitch2017 = []time.Time{
+	time.Date(2016, 12, 26, 0, 0, 0, 0, time.UTC),
+	time.Date(2016, 12, 27, 0, 0, 0, 0, time.UTC),
+	time.Date(2016, 12, 28, 0, 0, 0, 0, time.UTC),
+	time.Date(2016, 12, 29, 0, 0, 0, 0, time.UTC),
+	time.Date(2016, 12, 30, 0, 0, 0, 0, time.UTC),
+	time.Date(2016, 12, 31, 0, 0, 0, 0, time.UTC),
+	time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC),
+}
+
 func Test_NormalUsage(t *testing.T) {
 	var week, _ = NewWeek(2015, 46)
 	if len(week.Days) != 7 {
@@ -128,6 +138,16 @@ func Test_PreviousWeek(t *testing.T) {
 
 	if errA != nil {
 		t.Error(errA.Error())
+	}
+
+	var weekB, _ = NewWeek(2017, 1)
+	var previousWeekB, errB = weekB.Previous()
+	if !reflect.DeepEqual(expectedDaysForPreviousWeekWithYearSwitch2017, previousWeekB.Days) {
+		t.Errorf("Unexpected Week.Previous() with year switch, \n expected %v, \n given %v", expectedDaysForPreviousWeekWithYearSwitch2017, previousWeekB.Days)
+	}
+
+	if errB != nil {
+		t.Error(errB.Error())
 	}
 }
 


### PR DESCRIPTION
There's a bug when the previous week contains a year change (but not when the year change is in the current week.